### PR TITLE
Put prefix in quotes

### DIFF
--- a/DiscordIntegration.Bot/config.yml
+++ b/DiscordIntegration.Bot/config.yml
@@ -2,7 +2,7 @@
 token: your-bot-token
 
 # Bot commands prefix
-prefix: +
+prefix: "+"
 
 channels:
   # Channels to log various kind of messages in.


### PR DESCRIPTION
`+` as a prefix works without quotes but for example `!` doesn't.