### PR TITLE
Added ItemType to MedicalItem log

### DIFF
--- a/DiscordIntegration/Events/PlayerHandler.cs
+++ b/DiscordIntegration/Events/PlayerHandler.cs
@@ -252,9 +252,9 @@ namespace DiscordIntegration.Events
         public async void OnUsedMedicalItem(UsedItemEventArgs ev)
         {
             if (ev.Player != null && Instance.Config.EventsToLog.PlayerUsedMedicalItem && (!ev.Player.DoNotTrack || !Instance.Config.ShouldRespectDoNotTrack))
-                await Network.SendAsync(new RemoteCommand("log", "gameEvents", string.Format(Language.UsedMedicalItem, ev.Player.Nickname, Instance.Config.ShouldLogUserIds ? ev.Player.UserId : Language.Redacted, ev.Player.Role, ev.Item))).ConfigureAwait(false);
+                await Network.SendAsync(new RemoteCommand("log", "gameEvents", string.Format(Language.UsedMedicalItem, ev.Player.Nickname, Instance.Config.ShouldLogUserIds ? ev.Player.UserId : Language.Redacted, ev.Player.Role, ev.Item.Type))).ConfigureAwait(false);
             if (ev.Player != null && Instance.Config.StaffOnlyEventsToLog.PlayerUsedMedicalItem)
-                await Network.SendAsync(new RemoteCommand("log", "staffCopy", string.Format(Language.UsedMedicalItem, ev.Player.Nickname, ev.Player.UserId, ev.Player.Role, ev.Item))).ConfigureAwait(false);
+                await Network.SendAsync(new RemoteCommand("log", "staffCopy", string.Format(Language.UsedMedicalItem, ev.Player.Nickname, ev.Player.UserId, ev.Player.Role, ev.Item.Type))).ConfigureAwait(false);
         }
 
         public async void OnChangingRole(ChangingRoleEventArgs ev)


### PR DESCRIPTION
Currently, log viewers will only see the following when players use healing items. This PR allows the plugin to provide the actual ItemType of the healing item used instead.

![image](https://user-images.githubusercontent.com/54526517/134276149-c9b9fc9e-de08-4186-b960-1830fc95ff57.png)
