### PR TITLE
Fix message spam

### DIFF
--- a/DiscordIntegration.Bot/Bot.cs
+++ b/DiscordIntegration.Bot/Bot.cs
@@ -176,12 +176,12 @@ public class Bot
                         int i = 0;
                         while (msg.Length < 1900)
                         {
-                            msg += split[i];
+                            msg += split[i] + "\n";
                             i++;
                         }
 
                         _ = Guild.GetTextChannel(message.Key).SendMessageAsync(embed: await EmbedBuilderService.CreateBasicEmbed($"Server {ServerNumber} Logs", msg, Color.Green));
-                        messages.Add(message.Key, message.Value.Replace(msg, string.Empty));
+                        messages.Add(message.Key, message.Value.Substring(msg.Length));
                     }
                     else
                         _ = Guild.GetTextChannel(message.Key).SendMessageAsync(embed: await EmbedBuilderService.CreateBasicEmbed($"Server {ServerNumber} Logs", message.Value, Color.Green));


### PR DESCRIPTION
This PR should fix the message spam that sometimes happens. It seems like the issue was caused by DI incorrectly constructing a substring, then removing the substring from the initial message and adding it back. Because the substring was invalid, the entire initial message was added back which caused it to keep sending.

This PR makes sure that the substring is created correctly, and uses Substring instead of Replace, which should be a bit more performant but also makes it impossible for this issue to happen again (at least in this area) as part of the string will always be removed.